### PR TITLE
Ts with colored arrows

### DIFF
--- a/config/config_sample.json
+++ b/config/config_sample.json
@@ -8,6 +8,8 @@
         "sid": 2,
         "username": "Blechadler",
         "password": "<ENTER QUERY PASSWORD HERE>",
+        "join_emoji":  "arrow_right_green",
+        "leave_emoji": "arrow_left_red",
         "discordChannelIDs": ["296530538855137282"]
     },
     "birthdays": { 

--- a/config/config_sample.json
+++ b/config/config_sample.json
@@ -8,8 +8,8 @@
         "sid": 2,
         "username": "Blechadler",
         "password": "<ENTER QUERY PASSWORD HERE>",
-        "join_emoji":  "arrow_right_green",
-        "leave_emoji": "arrow_left_red",
+        "joinEmoji":  "arrow_right_green",
+        "leaveEmoji": "arrow_left_red",
         "discordChannelIDs": ["296530538855137282"]
     },
     "birthdays": { 

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,8 @@ interface TeamspeakConfig {
     username: string
     password: string
     discordChannelIDs: string[]
+    joinEmoji: string;
+    leaveEmoji: string;
 }
 
 interface BirthdaysConfig {

--- a/src/plugins/TeamspeakPlugin.ts
+++ b/src/plugins/TeamspeakPlugin.ts
@@ -11,14 +11,14 @@ export default class TeamspeakPlugin extends BlechadlerPlugin {
     private service!: TeamspeakService; // This is set in setup-method, which is called by the constructor
 
     protected setup (): void {
-        const { ip, port, sid, username, password } = config.teamspeak;
+        const { ip, port, sid, username, password, leaveEmoji, joinEmoji } = config.teamspeak;
         this.service = new TeamspeakService(ip, port, sid, username, password);
 
         // Send message to #ts channel, when user joins Teamspeak
         this.service.on('connected', ({ nickname, type, new: isNewUser }) => {
             if (type === TeamspeakUserType.Query) return;
 
-            this.sendMsg(`➡️  **${nickname}** joined`);
+            this.sendMsg(`:${joinEmoji}:  **${nickname}** joined`);
             if (isNewUser) this.sendMsg(`@here \`${nickname}\` ist neu`);
         });
 
@@ -26,7 +26,7 @@ export default class TeamspeakPlugin extends BlechadlerPlugin {
         this.service.on('disconnected', ({ nickname, type }) => {
             if (type === TeamspeakUserType.Query) return;
 
-            this.sendMsg(`⬅️  **${nickname}** left`);
+            this.sendMsg(`:${leaveEmoji}:  **${nickname}** left`);
         });
     }
 


### PR DESCRIPTION
Using these arrows with a different color for joining ad leaving instead of the current arrows makes for easier visual perception of who joined and left our TS.

(I personally always struggled with the `#ts` channel since I needed to read all the text to figure out what the Blechadler wants to tell me.)

Before:
![image](https://user-images.githubusercontent.com/76476468/142729313-9dc29326-2c04-4a74-b81a-f819485a2832.png)

After:
![Blechadler_mit_farbigen_Pfeilen](https://user-images.githubusercontent.com/76476468/143322097-0c6aebb0-0260-456c-a2c5-c56ed781f1b9.png)



